### PR TITLE
Fix admin routes and navigation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 
 from flask import Flask
+import os
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
 from flask_login import LoginManager
@@ -11,6 +12,7 @@ login_manager = LoginManager()
 def create_app():
     app = Flask(__name__)
     app.config.from_object('config.Config')
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
     db.init_app(app)
     csrf.init_app(app)
     login_manager.init_app(app)

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -18,7 +18,89 @@ def safe_filename(filename):
     name = re.sub(r'[^A-Za-z0-9_-]', '_', name)
     return f"{name}_{timestamp}{ext}"
 
-# (existing routes unchanged)
+@admin_bp.route('/')
+@login_required
+def admin_home():
+    page = request.args.get('page', 1, type=int)
+    search = request.args.get('search', '', type=str)
+    category_id = request.args.get('category_id', 0, type=int)
+    sort = request.args.get('sort', 'title')
+    direction = request.args.get('direction', 'asc')
+
+    query = Lesson.query
+    if search:
+        query = query.filter(Lesson.title.ilike(f"%{search}%"))
+    if category_id:
+        query = query.filter(Lesson.category_id == category_id)
+
+    order_func = asc if direction == 'asc' else desc
+    if sort == 'title':
+        query = query.order_by(order_func(Lesson.title))
+
+    pagination = query.paginate(page=page, per_page=10)
+    lessons = pagination.items
+    categories = Category.query.order_by(Category.name).all()
+    return render_template('admin/dashboard.html', lessons=lessons,
+                           pagination=pagination, categories=categories,
+                           search=search, category_id=category_id,
+                           sort=sort, direction=direction)
+
+@admin_bp.route('/category/new', methods=['GET', 'POST'])
+@login_required
+def new_category():
+    form = CategoryForm()
+    if form.validate_on_submit():
+        category = Category(name=form.name.data.strip())
+        db.session.add(category)
+        db.session.commit()
+        flash('Category added.')
+        return redirect(url_for('admin.admin_home'))
+    return render_template('admin/new_category.html', form=form)
+
+def lesson_form(lesson, form):
+    form.category.choices = [(c.id, c.name) for c in
+                             Category.query.order_by(Category.name)]
+    if form.validate_on_submit():
+        lesson.title = form.title.data
+        lesson.description = form.description.data
+        lesson.video_url = form.video_url.data
+        lesson.category_id = form.category.data
+        for file in form.pdf_files.data:
+            if file:
+                filename = safe_filename(file.filename)
+                path = os.path.join(current_app.config['UPLOAD_FOLDER'], filename)
+                file.save(path)
+                lesson.files.append(LessonFile(filename=filename))
+        db.session.add(lesson)
+        db.session.commit()
+        return redirect(url_for('admin.admin_home'))
+    return render_template('admin/new_lesson.html', form=form, lesson=lesson)
+
+@admin_bp.route('/lesson/new', methods=['GET', 'POST'])
+@login_required
+def new_lesson():
+    form = LessonForm()
+    lesson = Lesson()
+    return lesson_form(lesson, form)
+
+@admin_bp.route('/lesson/edit/<int:lesson_id>', methods=['GET', 'POST'])
+@login_required
+def edit_lesson(lesson_id):
+    lesson = Lesson.query.get_or_404(lesson_id)
+    form = LessonForm(obj=lesson)
+    return lesson_form(lesson, form)
+
+@admin_bp.route('/file/delete/<int:file_id>', methods=['POST'])
+@login_required
+def delete_file(file_id):
+    file = LessonFile.query.get_or_404(file_id)
+    lesson_id = file.lesson_id
+    file_path = os.path.join(current_app.config['UPLOAD_FOLDER'], file.filename)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+    db.session.delete(file)
+    db.session.commit()
+    return redirect(url_for('admin.edit_lesson', lesson_id=lesson_id))
 
 # New AJAX delete routes below:
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,7 +15,7 @@
         <a href="{{ url_for('main.home') }}">Home</a> |
         <a href="{{ url_for('main.about') }}">About</a>
         {% if current_user.is_authenticated %}
-        | <a href="{{ url_for('admin_home') }}">Admin</a>
+        | <a href="{{ url_for('admin.admin_home') }}">Admin</a>
         | <a href="{{ url_for('auth.logout') }}">Logout</a>
         {% endif %}
     </nav>


### PR DESCRIPTION
## Summary
- create upload folder on startup
- restore full admin routes for creating/editing lessons
- fix Admin link in base template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `FLASK_APP=manage.py flask routes | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_684ff96243bc832e8d315f9cbdec7a29