### PR TITLE
Fix registration errors and CSRF on delete

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -24,6 +24,7 @@
       {{ cat.name }}
       {% if cat.lessons|length == 0 %}
       <form action="{{ url_for('admin.delete_category', category_id=cat.id) }}" method="post" style="display:inline;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button class="tiny-delete" onclick="return confirm('Delete this empty category?')">🗑</button>
       </form>
       {% endif %}


### PR DESCRIPTION
## Summary
- handle database errors when registering a new user
- add CSRF token to delete category form

## Testing
- `python -m py_compile app/auth/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68545b328508832e9b84c4bd1581a99e