### PR TITLE
Fix registration dependency

### DIFF
--- a/app/forms/forms.py
+++ b/app/forms/forms.py
@@ -1,9 +1,15 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, SelectField, FileField, PasswordField, MultipleFileField, SubmitField
+from wtforms import (
+    StringField,
+    TextAreaField,
+    SelectField,
+    FileField,
+    PasswordField,
+    MultipleFileField,
+    SubmitField,
+)
 from wtforms.validators import DataRequired, ValidationError, Email, EqualTo, Length
 from ..models.models import User
-from flask_wtf import FlaskForm
-from wtforms import SubmitField
 
 MAX_FILE_SIZE_MB = 10
 

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -24,6 +24,7 @@
       {{ cat.name }}
       {% if cat.lessons|length == 0 %}
       <form action="{{ url_for('admin.delete_category', category_id=cat.id) }}" method="post" style="display:inline;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button class="tiny-delete" onclick="return confirm('Delete this empty category?')">🗑</button>
       </form>
       {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask-SQLAlchemy
 Flask-Login
 Werkzeug
 click
+email-validator


### PR DESCRIPTION
## Summary
- include missing `email-validator` in requirements
- clean up form definitions

## Testing
- `python -m py_compile app/auth/routes.py app/forms/forms.py`


------
https://chatgpt.com/codex/tasks/task_e_68545b328508832e9b84c4bd1581a99e