### PR TITLE
Fix login redirect and admin navbar visibility

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -15,7 +15,9 @@ def login():
         user = User.query.filter_by(username=form.username.data).first()
         if user and check_password_hash(user.password_hash, form.password.data):
             login_user(user)
-            return redirect(url_for('admin.admin_home'))
+            if user.is_admin:
+                return redirect(url_for('admin.admin_home'))
+            return redirect(url_for('main.home'))
         else:
             flash('Invalid username or password')
     return render_template('login.html', form=form)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,8 +15,10 @@
         <a href="{{ url_for('main.home') }}">Home</a> |
         <a href="{{ url_for('main.about') }}">About</a>
         {% if current_user.is_authenticated %}
-            | <a href="{{ url_for('admin.admin_home') }}">Admin</a>
-            | <a href="{{ url_for('admin.user_list') }}">Users</a>
+            {% if current_user.is_admin %}
+                | <a href="{{ url_for('admin.admin_home') }}">Admin</a>
+                | <a href="{{ url_for('admin.user_list') }}">Users</a>
+            {% endif %}
             | <a href="{{ url_for('auth.logout') }}">Logout</a>
         {% else %}
             | <a href="{{ url_for('auth.login') }}">Login</a>


### PR DESCRIPTION
## Summary
- route non-admin users to the home page after login
- only display admin links for admin users in the navigation bar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685464b3735c832e9ebed2079785d4c3