### PR TITLE
Fix login failure due to truncated password hash

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -9,7 +9,8 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(150), unique=True, nullable=False)
     email = db.Column(db.String(150), unique=True, nullable=False)
-    password_hash = db.Column(db.String(150), nullable=False)
+    # Increased length to prevent truncation of modern password hashes
+    password_hash = db.Column(db.String(255), nullable=False)
     is_admin = db.Column(db.Boolean, default=False)
 
     def set_password(self, password):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Werkzeug
 click
 email_validator
 Flask-Migrate
+pymysql


### PR DESCRIPTION
## Summary
- enlarge `password_hash` column so MySQL won't truncate long hashes
- add missing `pymysql` dependency for MySQL support

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68548a625980832e81f96f74ee15d77c