### PR TITLE
Fix lesson file grouping without display names

### DIFF
--- a/app/templates/lesson.html
+++ b/app/templates/lesson.html
@@ -14,8 +14,16 @@
 
 {% if lesson.files %}
   <h3>Resources:</h3>
-  {% set files_by_title = lesson.files|selectattr('display_name')|groupby('display_name') %}
-  {% for title, group in files_by_title %}
+  {% set grouped = namespace(data={}, others=[]) %}
+  {% for file in lesson.files %}
+    {% if file.display_name %}
+      {% set _ = grouped.data.setdefault(file.display_name, []).append(file) %}
+    {% else %}
+      {% set _ = grouped.others.append(file) %}
+    {% endif %}
+  {% endfor %}
+
+  {% for title, group in grouped.data.items() %}
     <div class="resource-card" style="margin-bottom: 1rem; padding: 1rem; background: #eee; border-radius: 0.5rem;">
       <strong>{{ title }}</strong><br>
       {% for file in group %}
@@ -23,6 +31,12 @@
           {{ file.file_type|capitalize }}
         </a>{% if not loop.last %} &nbsp;|&nbsp; {% endif %}
       {% endfor %}
+    </div>
+  {% endfor %}
+
+  {% for file in grouped.others %}
+    <div class="resource-card" style="margin-bottom: 1rem; padding: 1rem; background: #eee; border-radius: 0.5rem;">
+      <a href="{{ url_for('main.download_file', filename=file.filename) }}" target="_blank">{{ file.filename }}</a>
     </div>
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary
- handle lessons that have files without `display_name`

## Testing
- `venv/bin/python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68549b0922e0832e92f4eb153736b5f3