### PR TITLE
Fix lesson file grouping without display names

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -26,7 +26,21 @@ def lesson_view(lesson_id):
     """Display details for a single lesson."""
 
     lesson = Lesson.query.get_or_404(lesson_id)
-    return render_template('lesson.html', lesson=lesson)
+
+    grouped_files = {}
+    other_files = []
+    for file in lesson.files:
+        if file.display_name:
+            grouped_files.setdefault(file.display_name, []).append(file)
+        else:
+            other_files.append(file)
+
+    return render_template(
+        'lesson.html',
+        lesson=lesson,
+        grouped_files=grouped_files,
+        other_files=other_files,
+    )
 
 @main_bp.route('/uploads/<filename>')
 def download_file(filename):

--- a/app/templates/lesson.html
+++ b/app/templates/lesson.html
@@ -14,8 +14,7 @@
 
 {% if lesson.files %}
   <h3>Resources:</h3>
-  {% set files_by_title = lesson.files|selectattr('display_name')|groupby('display_name') %}
-  {% for title, group in files_by_title %}
+  {% for title, group in grouped_files.items() %}
     <div class="resource-card" style="margin-bottom: 1rem; padding: 1rem; background: #eee; border-radius: 0.5rem;">
       <strong>{{ title }}</strong><br>
       {% for file in group %}
@@ -23,6 +22,12 @@
           {{ file.file_type|capitalize }}
         </a>{% if not loop.last %} &nbsp;|&nbsp; {% endif %}
       {% endfor %}
+    </div>
+  {% endfor %}
+
+  {% for file in other_files %}
+    <div class="resource-card" style="margin-bottom: 1rem; padding: 1rem; background: #eee; border-radius: 0.5rem;">
+      <a href="{{ url_for('main.download_file', filename=file.filename) }}" target="_blank">{{ file.filename }}</a>
     </div>
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary
- handle lessons that have files without `display_name`
- group lesson files in the route instead of Jinja template

## Testing
- `venv/bin/python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68549b0922e0832e92f4eb153736b5f3