### PR TITLE
Fix new lesson page submit error

### DIFF
--- a/app/forms/forms.py
+++ b/app/forms/forms.py
@@ -43,6 +43,7 @@ class LessonForm(FlaskForm):
     video_url = StringField('Vimeo URL')
     category = SelectField('Category', coerce=int)
     pdf_files = MultipleFileField('Upload Worksheets & Answer Keys', validators=[file_size_limit])
+    submit = SubmitField('Save Lesson')
 
 class LoginForm(FlaskForm):
     """Authentication form for existing users."""


### PR DESCRIPTION
## Summary
- add a `SubmitField` to `LessonForm` so the template can render

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b73081f8832e9f3a4a72df0578e5